### PR TITLE
ipv4 forwarding comment is misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you want to override sysctl-variables, you can use the `sysctl_overwrite` var
         - dev-sec.os-hardening
       vars:
         sysctl_overwrite:
-          # Disable IPv4 traffic forwarding.
+          # Enable IPv4 traffic forwarding.
           net.ipv4.ip_forward: 1
 ```
 


### PR DESCRIPTION
fix to example configuration comment, indicating that feature is enabled (not disabled)

`net.ipv4.ip_forward: 1` indicates that `ip_forward` is enabled.

* expected:  comment indicates feature is enabled
* actual: comment indicates that this feature is disabled

